### PR TITLE
Plugin manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Writing Plugins
 It's pretty easy to write a new plugin. They're just Python modules with some common attributes:
 
 * A plugin must subclass ```porkchop.plugin.PorkchopPlugin```.
-* The plugin's class must be suffixed with ```Plugin```. Its actual file name in the plugin directory should also match the prefix. For example, ```FooPlugin``` would be in the file ```foo.py```
 * The plugin's class must contain a method called ```get_data``` that returns a dictionary of the information to be displayed.
+* The plugin's metric name will be derived from the module name (N.B. this means you'll only be able to define one plugin per module). To override the metric name, you may set the magic ```__metric_name__``` property on the plugin.
 
 By default, a plugin's ```get_data``` method will only be called if the data is more then 60 seconds old. This can be changed on a per-plugin basis by setting ```self.refresh``` in the class's ```___init___``` method.
 

--- a/porkchop/plugin.py
+++ b/porkchop/plugin.py
@@ -14,7 +14,6 @@ import sys
 import socket
 import time
 
-import porkchop.plugins
 from porkchop.util import PorkchopUtil
 
 
@@ -125,7 +124,11 @@ class PorkchopPluginHandler(object):
         if directory:
             self.__class__.plugins.update(self.load_plugins(directory))
 
-        self.__class__.plugins.update(self.load_plugins(os.path.dirname(porkchop.plugins.__file__)))
+        self.__class__.plugins.update(
+            self.load_plugins(
+                os.path.join(os.path.dirname(__file__), 'plugins')
+            )
+        )
 
     def load_plugins(self, directory):
         plugins = {}
@@ -138,20 +141,34 @@ class PorkchopPluginHandler(object):
 
         for infile in glob.glob(os.path.join(directory, '*.py')):
             module_name = os.path.splitext(os.path.split(infile)[1])[0]
-            if os.path.basename(infile) != '__init__.py' and \
-                (not to_load or module_name in to_load):
-                try:
-                    module = imp.load_source(module_name, infile)
-                    for k, v in inspect.getmembers(module):
-                        if inspect.isclass(v) and issubclass(v, PorkchopPlugin):
-                            if hasattr(v, '__metric_name__'):
-                                plugin_name = v.__metric_name__
-                            else:
-                                plugin_name = k
-                            plugins[plugin_name] = v
-                            plugins[plugin_name].config_file = os.path.join(self.config_dir,
-                                '%s.ini' % module_name)
-                except ImportError:
-                    pass
+
+            if os.path.basename(infile) == '__init__.py':
+                continue
+            if to_load and module_name not in to_load:
+                continue
+
+            try:
+                module = imp.load_source(module_name, infile)
+                for namek, klass in inspect.getmembers(module):
+                    if inspect.isclass(klass) \
+                       and issubclass(klass, PorkchopPlugin) \
+                       and klass is not PorkchopPlugin:
+
+                        if hasattr(klass, '__metric_name__'):
+                            plugin_name = klass.__metric_name__
+                        else:
+                            plugin_name = module_name
+
+                        plugins[plugin_name] = klass
+                        plugins[plugin_name].config_file = os.path.join(
+                            self.config_dir,
+                            '%s.ini' % module_name
+                        )
+
+                        # Only one plugin per module.
+                        break
+
+            except ImportError:
+                pass
 
         return plugins

--- a/porkchop/plugin.py
+++ b/porkchop/plugin.py
@@ -162,7 +162,7 @@ class PorkchopPluginHandler(object):
                         plugins[plugin_name] = klass
                         plugins[plugin_name].config_file = os.path.join(
                             self.config_dir,
-                            '%s.ini' % module_name
+                            '%s.ini' % plugin_name
                         )
 
                         # Only one plugin per module.


### PR DESCRIPTION
Change the way the plugin manager discovers and loads plugins. This change is to allow the rc_python module in https://github.com/disqus/porkchop-plugins/pull/10 to set its metric name to "redis".
